### PR TITLE
Update challenge01-acsintro.md

### DIFF
--- a/challenges/challenge01-acsintro.md
+++ b/challenges/challenge01-acsintro.md
@@ -48,7 +48,7 @@ In this lab, you will prepare your workstation VM for working with ACS and Kuber
 
 8. In your terminal git clone the repo for this Hackfest
     * ``git clone https://github.com/chzbrgr71/container-hackfest.git``
-    * cd into the ``/container-hackfest/challenges`` directory 
+    * cd into the ``~/container-hackfest/challenges`` directory 
 
 ## Advanced areas to explore
 


### PR DESCRIPTION
Changed leading forward-slash ("/") to "\~/" in statement "cd into the /container-hackfest/challenges directory" as the prior "git clone ..." command will clone the repo relative to your home directory ("~/"), not relative to the root ("/") of the filesystem.